### PR TITLE
Stable build ready for main (by way of branch-dev)

### DIFF
--- a/devops/azure-pipelines.yml
+++ b/devops/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
     type: github
     endpoint: Team1-Project3
     name: 1053-August-Duet-Project-Registry/project-registry-devops
-    ref: refs/heads/branch-dev
+    ref: refs/heads/main
 
 # This pipeline will trigger on commits or pull-requests made to the branch-dev 
 # or main branches.  Note that complete static analysis with SonarCloud is only 


### PR DESCRIPTION
Depends on: https://github.com/1053-August-Duet-Project-Registry/project-registry-devops/pull/13

The only difference here is updating the templates to look to `main` now that the above-mentioned PR has pulled the templates into `main`.

We will also be pulling this change into `main` soon.